### PR TITLE
[APM-72] Update poms to generate two packages

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -120,6 +120,18 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.cognifide.cq.actions</groupId>
+            <artifactId>com.cognifide.cq.actions.api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.cognifide.cq.actions</groupId>
+            <artifactId>com.cognifide.cq.actions.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.cognifide.cq.actions</groupId>
+            <artifactId>com.cognifide.cq.actions.msg.replication</artifactId>
+        </dependency>
     </dependencies>
     <parent>
         <groupId>com.cognifide.cq</groupId>
@@ -146,6 +158,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
+                	<classifier>no-actions</classifier>
                     <instructions>
                         <Export-Package>
                             com.cognifide.cq.cqsm.foundation.actions.*;com.cognifide.cq.cqsm.api.*;com.cognifide.cq.cqsm.core.models.*;com.cognifide.cq.cqsm.core.automaticexecutor.*;version="${project.version}"
@@ -160,6 +173,21 @@
                         <CQ-Security-Management-Actions>com.cognifide.cq.cqsm.foundation.actions</CQ-Security-Management-Actions>
                     </instructions>
                 </configuration>
+                <executions>
+                	<execution>
+                	    <id>package-with-emedded-action</id>
+                	    <phase>package</phase>
+                	    <goals>
+					        <goal>bundle</goal>
+					    </goals>
+                		<configuration>
+                			<classifier>with-actions</classifier>
+                        	<instructions>
+                				<Embed-Dependency>gson,guava,com.cognifide.cq.actions.api,com.cognifide.cq.actions.core,com.cognifide.cq.actions.msg.replication</Embed-Dependency>
+                			</instructions>
+                    	</configuration>
+                	</execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.sling</groupId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -158,7 +158,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                	<classifier>no-actions</classifier>
+                    <classifier>no-actions</classifier>
                     <instructions>
                         <Export-Package>
                             com.cognifide.cq.cqsm.foundation.actions.*;com.cognifide.cq.cqsm.api.*;com.cognifide.cq.cqsm.core.models.*;com.cognifide.cq.cqsm.core.automaticexecutor.*;version="${project.version}"
@@ -174,19 +174,19 @@
                     </instructions>
                 </configuration>
                 <executions>
-                	<execution>
-                	    <id>package-with-emedded-action</id>
-                	    <phase>package</phase>
-                	    <goals>
-					        <goal>bundle</goal>
-					    </goals>
-                		<configuration>
-                			<classifier>with-actions</classifier>
-                        	<instructions>
-                				<Embed-Dependency>gson,guava,com.cognifide.cq.actions.api,com.cognifide.cq.actions.core,com.cognifide.cq.actions.msg.replication</Embed-Dependency>
-                			</instructions>
-                    	</configuration>
-                	</execution>
+                    <execution>
+                        <id>package-with-emedded-action</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>with-actions</classifier>
+                            <instructions>
+                                <Embed-Dependency>gson,guava,com.cognifide.cq.actions.api,com.cognifide.cq.actions.core,com.cognifide.cq.actions.msg.replication</Embed-Dependency>
+                            </instructions>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -10,6 +10,13 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>cqsm-bundle</artifactId>
             <version>${project.version}</version>
+            <classifier>no-actions</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cqsm-bundle</artifactId>
+            <version>${project.version}</version>
+            <classifier>with-actions</classifier>
         </dependency>
     </dependencies>
     <parent>
@@ -52,33 +59,91 @@
                     <name>apm</name>
                     <group>com.cognifide.aem</group>
                     <filterSource>src/main/content/META-INF/vault/filter.xml</filterSource>
-                    <embeddeds>
-                        <embedded>
-                            <groupId>${project.groupId}</groupId>
-                            <artifactId>cqsm-bundle</artifactId>
-                            <target>/apps/cqsm/install</target>
-                        </embedded>
-                        <embedded>
-                            <groupId>com.cognifide.cq.actions</groupId>
-                            <artifactId>com.cognifide.cq.actions.api</artifactId>
-                            <target>/apps/cqsm/install</target>
-                        </embedded>
-                        <embedded>
-                            <groupId>com.cognifide.cq.actions</groupId>
-                            <artifactId>com.cognifide.cq.actions.core</artifactId>
-                            <target>/apps/cqsm/install</target>
-                        </embedded>
-                        <embedded>
-                            <groupId>com.cognifide.cq.actions</groupId>
-                            <artifactId>com.cognifide.cq.actions.msg.replication</artifactId>
-                            <target>/apps/cqsm/install</target>
-                        </embedded>
-                    </embeddeds>
                     <targetURL>http://${crx.host}:${crx.port}/crx/packmgr/service.jsp</targetURL>
                     <properties>
                         <acHandling>merge</acHandling>
                     </properties>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>dependencies-embed</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        
+                        <configuration>
+                            <finalName>${project.build.finalName}-embed</finalName>
+                            <embeddeds>
+                                <embedded>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>cqsm-bundle</artifactId>
+                                    <classifier>with-actions</classifier>
+                                    <target>/apps/cqsm/install</target>
+                                </embedded>
+                            </embeddeds>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>dependencies-install</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <embeddeds>
+                                <embedded>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>cqsm-bundle</artifactId>
+                                    <classifier>no-actions</classifier>
+                                    <target>/apps/cqsm/install</target>
+                                </embedded>
+                                <embedded>
+                                    <groupId>com.cognifide.cq.actions</groupId>
+                                    <artifactId>com.cognifide.cq.actions.api</artifactId>
+                                    <target>/apps/cqsm/install</target>
+                                </embedded>
+                                <embedded>
+                                    <groupId>com.cognifide.cq.actions</groupId>
+                                    <artifactId>com.cognifide.cq.actions.core</artifactId>
+                                    <target>/apps/cqsm/install</target>
+                                </embedded>
+                                <embedded>
+                                    <groupId>com.cognifide.cq.actions</groupId>
+                                    <artifactId>com.cognifide.cq.actions.msg.replication</artifactId>
+                                    <target>/apps/cqsm/install</target>
+                                </embedded>
+                            </embeddeds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>install-embed-package</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}\${project.build.finalName}-embed.zip</file>
+                            <pomFile>${basedir}\pom.xml</pomFile>
+                            <classifier>embed</classifier>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-default-package</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}\${project.build.finalName}.zip</file>
+                            <pomFile>${basedir}\pom.xml</pomFile>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.7</version>
+                    <version>3.2.0</version>
                     <extensions>true</extensions>
                     <configuration>
                         <instructions>


### PR DESCRIPTION
 Update poms to generate two packages - default one with CQ Actions in install folder of generated package, and second one - with CQ Actions embedded in APM bundle

Reason for having two separate packages is to fit situation, when on AEM instance there is already CQ Actions installed with different version than the one used by APM.

Tech notes: The reason why also default bundle uses classifier is that content-package-maven-plugin plugin cannot handle bundles with classifier properly (when trying to filter out bundle without classifier, bundles with every classifier found are incuded in resulting package).
It seems that  content-package-maven-plugin executions have got influence on main artifact name. Thats why package with embedded actions is built first, and default one second.

---

I hereby agree to the terms of the APM Contributor License Agreement.