### PR TITLE
[APM-132] Fix Displaying Summary Table after Script Run

### DIFF
--- a/content/src/main/content/jcr_root/etc/designs/cqsm/clientlibs/js/cqsmImport.js
+++ b/content/src/main/content/jcr_root/etc/designs/cqsm/clientlibs/js/cqsmImport.js
@@ -71,7 +71,7 @@ Cog.component.cqsmImport = (function ($) {
             success: function (data) {
                 var jobId = JSON.parse(data).id;
 
-                (function checkStatus(jobId) {
+                setTimeout(function(){(function checkStatus(jobId) {
                     $.ajax({
                         type: "GET",
                         url: "/bin/cqsm/run-background?id=" + jobId,
@@ -80,8 +80,6 @@ Cog.component.cqsmImport = (function ($) {
                             var dataObject = JSON.parse(data);
                             if (dataObject.type === 'running') {
                                 setTimeout(function(){checkStatus(jobId)}, 1000);
-                            } else if (dataObject.type === 'finished') {
-                                renderProgress(fileName, mode, jobId, item, start);
                             } else if (dataObject.type === 'unknown') {
                                 var time = new Date().getTime() - start;
                                 helper.showMessage("File: " + fileName + "<br>Mode: " + mode + "<br>Executed with errors in " + time + " ms", dataObject.type, true);
@@ -89,9 +87,12 @@ Cog.component.cqsmImport = (function ($) {
                                     context: $("#cqsmImportPage")
                                 });
                             }
+                        },
+                        complete: function () {
+                            renderProgress(fileName, mode, jobId, item, start);
                         }
                     });
-                })(jobId);
+                })(jobId)}, 100);
             }
         });
     }


### PR DESCRIPTION
It fixes the issue with displaying summary table that I've been observing during use of the APM tool.

It affects the Front-End part only, because actions run in the scripts have been applied correctly.
The fix actually adds small timeout for self-executing function `checkStatus(jobId)`

---

I hereby agree to the terms of the APM Contributor License Agreement.