### PR TITLE
APM-62-Fix-displaying-empty-file

### DIFF
--- a/content/src/main/content/jcr_root/apps/apm/clientlibs/views/editor/js/apm-edit.js
+++ b/content/src/main/content/jcr_root/apps/apm/clientlibs/views/editor/js/apm-edit.js
@@ -93,7 +93,7 @@
             }
 
             content.push('');
-            content.push(params[file].content || params[file]);
+            content.push(params[file].content);
             content.push('--' + boundary);
           }
         }


### PR DESCRIPTION
Displaying empty object as string removed