### PR TITLE
APM-59-Fix-JS-error-while-selecting-file-at-IE11

### DIFF
--- a/content/src/main/content/jcr_root/apps/apm/clientlibs/views/scripts/js/apm-scripts.js
+++ b/content/src/main/content/jcr_root/apps/apm/clientlibs/views/scripts/js/apm-scripts.js
@@ -295,11 +295,11 @@
   }
 
   function isFolder(selection) {
-    return selection.items._container.innerHTML.includes('folder');
+    return selection.items._container.innerHTML.indexOf('folder') > -1;
   }
 
   function isScriptInvalidOrNonExecutable(selection) {
-    return selection.items._container.innerHTML.includes('script-is-invalid');
+    return selection.items._container.innerHTML.indexOf('script-is-invalid') > -1;
   }
 
 })(window, jQuery);


### PR DESCRIPTION
includes method replaced by indexOf method as IE11 does not support
includes method